### PR TITLE
feat(router): integrate main routing structure with placeholder pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^7.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -1927,6 +1928,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2899,6 +2908,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
+      "dependencies": {
+        "react-router": "7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2999,6 +3044,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,16 @@
-import './App.css'
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import RepoListPage from './pages/RepoList';
+import RepoDetailPage from './pages/RepoDetail/RepoDetailPage';
 
 function App() {
   return (
-    <div className="container">
-      <h1>GoDaddyHub</h1>
-      <p className="subtitle">
-        Explore GoDaddy's public GitHub repositories in one place.
-      </p>
-      <p className="description">
-        View repository details like description, languages, forks, issues, and watchers.
-      </p>
-    </div>
-  )
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<RepoListPage />} />
+        <Route path="/repo/:name" element={<RepoDetailPage />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
-export default App
+export default App;

--- a/src/pages/RepoDetail/RepoDetailPage.tsx
+++ b/src/pages/RepoDetail/RepoDetailPage.tsx
@@ -1,0 +1,8 @@
+import { useParams } from 'react-router-dom';
+
+function RepoDetailPage() {
+  const { name } = useParams<{ name: string }>();
+  return <h2>Details for repository: {name}</h2>;
+}
+
+export default RepoDetailPage;

--- a/src/pages/RepoList/RepoListPage.tsx
+++ b/src/pages/RepoList/RepoListPage.tsx
@@ -1,0 +1,5 @@
+function RepoListPage() {
+  return <h2>Go daddy hub Repository List Page</h2>;
+}
+
+export default RepoListPage;

--- a/src/pages/RepoList/index.ts
+++ b/src/pages/RepoList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RepoListPage';


### PR DESCRIPTION
## Summary

Set up routing for the application using React Router. 

## What was done

- Installed `react-router-dom` 
- Created two route-level page folders:
  - `RepoList/` (for `/`)
  - `RepoDetail/` (for `/repo/:name`)
- Implemented basic mock components inside each page
- Wrapped the app with BrowserRouter provider

## Screenshot (if applicable)

Repo list mock route
<img width="1512" height="908" alt="image" src="https://github.com/user-attachments/assets/28958379-68b3-4f4f-beca-faf93fe39c9d" />

Repo detail mock route

<img width="1176" height="874" alt="image" src="https://github.com/user-attachments/assets/798dadcf-a266-4d2b-8e4c-8a9a82b40d7e" />
