### PR TITLE
feat(e2e): Adding e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# E2E
+e2e/test-results

--- a/e2e/repo-detail-api.spec.ts
+++ b/e2e/repo-detail-api.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('repo detail loads data from API', async ({ page }) => {
+  await page.goto('/');
+  const firstCard = page.getByTestId('repo-card').first();
+  await expect(firstCard).toBeVisible();
+  const repoName = await firstCard.locator('h6').textContent();
+  await firstCard.click();
+  const detailTitle = page.getByTestId('repo-detail-title');
+  await expect(detailTitle).toBeVisible();
+  await expect(detailTitle).toHaveText(repoName?.trim() || '');
+  await expect(page.getByText('Languages')).toBeVisible();
+}); 

--- a/e2e/repo-detail.spec.ts
+++ b/e2e/repo-detail.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('can navigate to repo detail from list', async ({ page }) => {
+  await page.goto('/');
+  const firstCard = page.getByTestId('repo-card').first();
+  await expect(firstCard).toBeVisible();
+  await firstCard.click();
+  await expect(page.getByTestId('page-title')).toBeVisible();
+}); 

--- a/e2e/repo-list-api.spec.ts
+++ b/e2e/repo-list-api.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test('repo list loads data from API', async ({ page }) => {
+  await page.goto('/');
+  const cards = page.getByTestId('repo-card');
+  await expect(cards.first()).toBeVisible();
+  await expect(cards.nth(1)).toBeVisible();
+  const firstRepoName = await cards.first().locator('h6').textContent();
+  expect(firstRepoName?.length).toBeGreaterThan(0);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@playwright/test": "^1.54.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/jest": "^29.0.0",
@@ -35,6 +36,7 @@
         "globals": "^16.3.0",
         "jest": "^29.0.0",
         "jest-environment-jsdom": "^30.0.5",
+        "playwright": "^1.54.1",
         "prettier": "^3.6.2",
         "ts-jest": "^29.0.0",
         "typescript": "~5.8.3",
@@ -2558,6 +2560,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.1.tgz",
+      "integrity": "sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7251,6 +7269,51 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.1.tgz",
+      "integrity": "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.1.tgz",
+      "integrity": "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write .",
     "preview": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@playwright/test": "^1.54.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.0.0",
@@ -39,6 +41,7 @@
     "globals": "^16.3.0",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^30.0.5",
+    "playwright": "^1.54.1",
     "prettier": "^3.6.2",
     "ts-jest": "^29.0.0",
     "typescript": "~5.8.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30 * 1000,
+  expect: { timeout: 5000 },
+  fullyParallel: true,
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+  ],
+});

--- a/src/pages/RepoDetail/RepoDetailPage.tsx
+++ b/src/pages/RepoDetail/RepoDetailPage.tsx
@@ -104,7 +104,7 @@ function RepoDetailPage() {
           </IconButton>
         </Tooltip>
         <CardContent>
-          <Typography variant="h6" fontWeight={700} mb={1}>
+          <Typography variant="h6" fontWeight={700} mb={1} data-testid="repo-detail-title">
             {repo.name}
           </Typography>
           <Typography variant="body1" color="text.secondary" mb={2}>

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
## Summary

This PR adds the first set of end-to-end (E2E) tests using Playwright. These tests simulate real user flows to validate the core functionality of the app in a browser environment.

## What was done

-  Set up Playwright with default configuration
-  Added base E2E test for visiting the Repo List Page
-  Added test for navigating to and validating the Repo Detail Page

## Screenshot (if applicable)

<img width="667" height="250" alt="image" src="https://github.com/user-attachments/assets/7645978d-4b9e-4c37-90d5-0866700276cb" />
